### PR TITLE
Use lastIndexOf in group mapping

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -569,7 +569,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             groups = new GroupMapping(groupsMapping.size());
 
             for (String groupMapping : groupsMapping) {
-                int index = groupMapping.indexOf('=');
+                int index = groupMapping.lastIndexOf('=');
 
                 if (index != -1) {
                     String xwikiGroup = toXWikiGroup(groupMapping.substring(0, index));


### PR DESCRIPTION
This allows '=' in group names

Currently `oidc.groups.mapping=id=xyz=XWikiAdminGroup` will not work correctly, as it checks for the first equal sign that is found (in this case the = after 'id') instead of checking for the last occurence