### PR TITLE
Add prefix for group names and support for groups returned as comma delimited string from IdP

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -672,7 +672,8 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     
     public boolean isGroupCommaDelimited()
     {
-        return getProperty(PROP_GROUPS_ISCOMMADELIMITED, Boolean.class);
+    	Boolean isCommaDelimited = getProperty(PROP_GROUPS_ISCOMMADELIMITED, Boolean.class);
+        return (isCommaDelimited!=null)?isCommaDelimited:false;
     }
     
     // Session only

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -214,7 +214,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
 
     public static final String PROP_GROUPS_PREFIX = "oidc.groups.prefix";
     
-    public static final String PROP_GROUPS_ISCOMMADELIMITED = "oidc.groups.isCommaDelimited";
+    public static final String PROP_GROUPS_SEPARATOR = "oidc.groups.separator";
     
     public static final String PROP_INITIAL_REQUEST = "xwiki.initialRequest";
 
@@ -670,10 +670,9 @@ public class OIDCClientConfiguration extends OIDCConfiguration
         return groupPrefix != null && !groupPrefix.isEmpty() ? groupPrefix : null;
     }
     
-    public boolean isGroupCommaDelimited()
+    public String getGroupSeparator()
     {
-    	Boolean isCommaDelimited = getProperty(PROP_GROUPS_ISCOMMADELIMITED, Boolean.class);
-        return (isCommaDelimited!=null)?isCommaDelimited:false;
+        return getProperty(PROP_GROUPS_SEPARATOR, String.class);
     }
     
     // Session only

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -212,6 +212,10 @@ public class OIDCClientConfiguration extends OIDCConfiguration
      */
     public static final String PROP_GROUPS_FORBIDDEN = "oidc.groups.forbidden";
 
+    public static final String PROP_GROUPS_PREFIX = "oidc.groups.prefix";
+    
+    public static final String PROP_GROUPS_ISCOMMADELIMITED = "oidc.groups.isCommaDelimited";
+    
     public static final String PROP_INITIAL_REQUEST = "xwiki.initialRequest";
 
     public static final String PROP_STATE = "oidc.state";
@@ -660,6 +664,17 @@ public class OIDCClientConfiguration extends OIDCConfiguration
         return groups != null && !groups.isEmpty() ? groups : null;
     }
 
+    public String getGroupPrefix()
+    {
+        String groupPrefix = getProperty(PROP_GROUPS_PREFIX, String.class);
+        return groupPrefix != null && !groupPrefix.isEmpty() ? groupPrefix : null;
+    }
+    
+    public boolean isGroupCommaDelimited()
+    {
+        return getProperty(PROP_GROUPS_ISCOMMADELIMITED, Boolean.class);
+    }
+    
     // Session only
 
     /**

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -44,6 +46,7 @@ import javax.inject.Singleton;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.RegExUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.securityfilter.realm.SimplePrincipal;
@@ -234,7 +237,21 @@ public class OIDCUserManager
 
     private void checkAllowedGroups(UserInfo userInfo) throws OIDCException
     {
-        List<String> providerGroups = getClaim(this.configuration.getGroupClaim(), userInfo);
+    	List<String> providerGroups = null;
+        Object providerGroupsObj = getClaim(this.configuration.getGroupClaim(), userInfo);
+        if (this.configuration.isGroupCommaDelimited()) {        
+        	providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), ","));
+        } else {
+        	providerGroups = (List<String>)providerGroupsObj;
+        }
+        String groupPrefix = this.configuration.getGroupPrefix();
+        if (!StringUtils.isEmpty(groupPrefix)) {
+        	providerGroups = providerGroups.stream()
+        			.filter(item -> item.startsWith(groupPrefix))
+        			.map(item -> StringUtils.replace(item, groupPrefix, ""))
+        			.collect(Collectors.toList());
+        }
+        
         if (providerGroups != null) {
             // Check allowed groups
             List<String> allowedGroups = this.configuration.getAllowedGroups();
@@ -468,7 +485,21 @@ public class OIDCUserManager
 
         this.logger.debug("Getting groups sent by the provider associated with claim [{}]", groupClaim);
 
-        List<String> providerGroups = (List<String>) getClaim(groupClaim, userInfo);
+    	List<String> providerGroups = null;
+        Object providerGroupsObj = getClaim(this.configuration.getGroupClaim(), userInfo);
+        if (this.configuration.isGroupCommaDelimited()) {
+        	providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), ","));
+        } else {
+        	providerGroups = (List<String>)providerGroupsObj;
+        }
+        String groupPrefix = this.configuration.getGroupPrefix();
+        if (!StringUtils.isEmpty(groupPrefix)) {
+        	providerGroups = providerGroups.stream()
+        			.filter(item -> item.startsWith(groupPrefix))
+        			.map(item -> StringUtils.replace(item, groupPrefix, ""))
+        			.collect(Collectors.toList());
+        }
+        
         if (providerGroups != null) {
             this.logger.debug("The provider sent the following groups: {}", providerGroups);
 

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -237,19 +237,19 @@ public class OIDCUserManager
 
     private void checkAllowedGroups(UserInfo userInfo) throws OIDCException
     {
-    	List<String> providerGroups = null;
+        List<String> providerGroups = null;
         Object providerGroupsObj = getClaim(this.configuration.getGroupClaim(), userInfo);
-        if (this.configuration.isGroupCommaDelimited()) {        
-        	providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), ","));
+        if (this.configuration.getGroupSeparator()!=null) {
+            providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), this.configuration.getGroupSeparator()));
         } else {
-        	providerGroups = (List<String>)providerGroupsObj;
+            providerGroups = (List<String>)providerGroupsObj;
         }
         String groupPrefix = this.configuration.getGroupPrefix();
         if (!StringUtils.isEmpty(groupPrefix)) {
-        	providerGroups = providerGroups.stream()
-        			.filter(item -> item.startsWith(groupPrefix))
-        			.map(item -> StringUtils.replace(item, groupPrefix, ""))
-        			.collect(Collectors.toList());
+            providerGroups = providerGroups.stream()
+                    .filter(item -> item.startsWith(groupPrefix))
+                    .map(item -> StringUtils.replace(item, groupPrefix, ""))
+                    .collect(Collectors.toList());
         }
         
         if (providerGroups != null) {
@@ -485,19 +485,19 @@ public class OIDCUserManager
 
         this.logger.debug("Getting groups sent by the provider associated with claim [{}]", groupClaim);
 
-    	List<String> providerGroups = null;
+        List<String> providerGroups = null;
         Object providerGroupsObj = getClaim(this.configuration.getGroupClaim(), userInfo);
-        if (this.configuration.isGroupCommaDelimited()) {
-        	providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), ","));
+        if (this.configuration.getGroupSeparator()!=null) {
+            providerGroups = Arrays.asList(StringUtils.split(providerGroupsObj.toString(), this.configuration.getGroupSeparator()));
         } else {
-        	providerGroups = (List<String>)providerGroupsObj;
+            providerGroups = (List<String>)providerGroupsObj;
         }
         String groupPrefix = this.configuration.getGroupPrefix();
         if (!StringUtils.isEmpty(groupPrefix)) {
-        	providerGroups = providerGroups.stream()
-        			.filter(item -> item.startsWith(groupPrefix))
-        			.map(item -> StringUtils.replace(item, groupPrefix, ""))
-        			.collect(Collectors.toList());
+            providerGroups = providerGroups.stream()
+                    .filter(item -> item.startsWith(groupPrefix))
+                    .map(item -> StringUtils.replace(item, groupPrefix, ""))
+                    .collect(Collectors.toList());
         }
         
         if (providerGroups != null) {


### PR DESCRIPTION
I added an optional parameter "oidc.groups.isCommaDelimited" to manage group names returned as comma delimited string from an Identity Provider, such as WSO2 IDS.
Then I added another optional property "oidc.groups.prefix" to sync only group names that starts with this value, to avoid unwanted provisioning.
I hope this is useful. 