### PR TITLE
Log failure of OIDC user info request

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -181,7 +181,14 @@ public class OIDCUserManager
         userInfoEndpoint.prepare(userinfoHTTP);
         this.logger.debug("OIDC user info request ({}?{},{})", userinfoHTTP.getURL(), userinfoHTTP.getQuery(),
             userinfoHTTP.getHeaderMap());
-        HTTPResponse httpResponse = userinfoHTTP.send();
+
+        HTTPResponse httpResponse;
+        try {
+            httpResponse = userinfoHTTP.send();
+        } catch (IOException e) {
+            this.logger.error("OIDC user info request failed ({}?{} => {})", userinfoHTTP.getURL(), userinfoHTTP.getQuery(), e);
+            throw e;
+        }
         this.logger.debug("OIDC user info response ({})", httpResponse.getContent());
         UserInfoResponse userinfoResponse = UserInfoResponse.parse(httpResponse);
 


### PR DESCRIPTION
When the userinfo request fails there is no evidence in of this in the debug logs.
The only indication was that "OIDC user info response" is missing after "OIDC user info request" log message.

This occurs for example if the xwiki server ist not allowed outgoing requests.