### PR TITLE
use idToken for group claims if claim is not found in userInfo token

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -413,7 +413,7 @@ public class OIDCUserManager
 
         // Sync user groups with the provider
         if (this.configuration.isGroupSync()) {
-            userUpdated = updateGroupMembership(idToken, userInfo, userDocument, xcontext);
+            userUpdated |= updateGroupMembership(idToken, userInfo, userDocument, xcontext);
         }
 
         // Notify


### PR DESCRIPTION
If the authenticator is used with Azure AD the group claims are not present in the userInfo token. They can be found in idToken.
