### PR TITLE
Initial groups are overwritten by OIDC group synchronisation

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -596,8 +596,15 @@ public class OIDCUserManager
             }
         }
 
+        // The value of the configuration option "xwiki.users.initialGroups" is not accessible from XWiki.class.
+        // The default value of the configuration option is copied here.
+        String defaultGroup = "XWiki.XWikiAllGroup"; // From XWiki.setUserDefaultGroup
+
         // Remove group membership
         for (String xwikiGroupName : xwikiUserGroupList) {
+            if (xwikiGroupName.equals(defaultGroup) ) {
+                continue; // do not remove default group
+            }
             if (groupMapping == null) {
                 if (!providerGroups.contains(xwikiGroupName)
                     && !providerGroups.contains(xwikiGroupName.substring(XWIKI_GROUP_PREFIX.length()))) {


### PR DESCRIPTION
The initial groups (xwiki.users.initialgroups) are removed immediately by the group synchronisation.

This fix hardcodes the xwiki.users.initialgroups configuration value. A better fix needs this value to be exported from XWiki.class.