### PR TITLE
[OIDC-167] [OIDC-168] Add basics for step-up authentication: Allow configuring full claims JSON and validate returned ACR

### DIFF
--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -804,7 +804,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
      */
     public OIDCClaimsRequest getClaimsRequest()
     {
-        // parse the complete claims JSON if configured
+        // Parse the complete claims JSON if configured
         String claimsJson = getProperty(PROP_CLAIMS, String.class);
         OIDCClaimsRequest claimsRequest = null;
         if (claimsJson != null && claimsJson.trim().length() > 0) {
@@ -815,7 +815,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             }
         }
         
-        // use idtokenclaims + userinfoclaims if json was not specified or if there was a parser error
+        // Use idtokenclaims + userinfoclaims if json was not specified or if there was a parser error
         if (claimsRequest == null) {
             claimsRequest = new OIDCClaimsRequest();
             

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -811,7 +811,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             try {
                 claimsRequest = OIDCClaimsRequest.parse(claimsJson);
             } catch (ParseException e) {
-                this.logger.warn("Parsing claims JSON failed: ", e.getMessage());
+                this.logger.warn("Parsing claims JSON " + claimsJson + "failed with message:" + e.getMessage());
             }
         }
         

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -47,6 +47,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -811,7 +812,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             try {
                 claimsRequest = OIDCClaimsRequest.parse(claimsJson);
             } catch (ParseException e) {
-                this.logger.warn("Parsing claims JSON " + claimsJson + "failed with message:" + e.getMessage());
+                this.logger.warn("Parsing claims JSON [{}] failed with message: {}", claimsJson, ExceptionUtils.getRootCauseMessage(e));
             }
         }
         

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -244,7 +244,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     public static final String PROP_SCOPE = "oidc.scope";
     
     /**
-     * @since 2.5.2
+     * @since 2.6.0
      */
     public static final String PROP_CLAIMS = "oidc.claims";
 

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/endpoint/CallbackOIDCEndpoint.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/endpoint/CallbackOIDCEndpoint.java
@@ -263,7 +263,7 @@ public class CallbackOIDCEndpoint implements OIDCEndpoint
                 // If any ACR was requested, fail if the ACR value in the id token is not present or does not match
                 if (!requestedAcrValues.isEmpty()) {
                     ACR idTokenAcr = idToken.getACR();
-                    if (idTokenAcr == null || !requestedAcrValues.contains(idToken.getACR().getValue())) {
+                    if (idTokenAcr == null || !requestedAcrValues.contains(idTokenAcr.getValue())) {
                         throw new OIDCException("Invalid ACR in id token. Requested: " 
                             + String.join(", ", requestedAcrValues) + " Received: " + idTokenAcr);
                     }

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
@@ -46,13 +46,13 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.nimbusds.oauth2.sdk.GeneralException;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.claims.ClaimRequirement;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.xpn.xwiki.web.XWikiServletRequestStub;
 
-import net.minidev.json.JSONObject;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -295,19 +295,23 @@ class OIDCClientConfigurationTest
         when(this.sourceConfiguration.getProperty(OIDCClientConfiguration.PROP_CLAIMS, String.class)).thenReturn(claimsJson);
 
         OIDCClaimsRequest claimsRequest = this.configuration.getClaimsRequest();
-        JSONObject finalJsonObject = claimsRequest.toJSONObject();
-        JSONObject finalUserInfoObject = (JSONObject) finalJsonObject.get("userinfo");
-        JSONObject finalIdTokenObject = (JSONObject) finalJsonObject.get("id_token");
-
-        assertEquals("{\"essential\":true}", finalUserInfoObject.getAsString("given_name"));
-        assertEquals(null, finalUserInfoObject.getAsString("nickname"));
-        assertEquals("{\"essential\":true}", finalUserInfoObject.getAsString("email"));
-        assertEquals("{\"essential\":true}", finalUserInfoObject.getAsString("email_verified"));
-        assertEquals(null, finalUserInfoObject.getAsString("picture"));
-        assertEquals(null, finalUserInfoObject.getAsString("http://example.info/claims/groups"));
+        ClaimsSetRequest userInfoClaimsRequest = claimsRequest.getUserInfoClaimsRequest();
+        ClaimsSetRequest idTokenClaimsRequest = claimsRequest.getIDTokenClaimsRequest();
         
-        assertEquals("{\"essential\":true}", finalIdTokenObject.getAsString("auth_time"));
-        assertEquals("{\"values\":[\"urn:mace:incommon:iap:silver\"]}", finalIdTokenObject.getAsString("acr"));
+        assertNotNull(userInfoClaimsRequest.get("given_name"));
+        assertEquals(ClaimRequirement.ESSENTIAL, userInfoClaimsRequest.get("given_name").getClaimRequirement());
+        assertNotNull(userInfoClaimsRequest.get("nickname"));
+        assertNotNull(userInfoClaimsRequest.get("email"));
+        assertEquals(ClaimRequirement.ESSENTIAL, userInfoClaimsRequest.get("email").getClaimRequirement());
+        assertNotNull(userInfoClaimsRequest.get("email_verified"));
+        assertEquals(ClaimRequirement.ESSENTIAL, userInfoClaimsRequest.get("email_verified").getClaimRequirement());
+        assertNotNull(userInfoClaimsRequest.get("picture"));
+        assertNotNull(userInfoClaimsRequest.get("http://example.info/claims/groups"));
+        
+        assertNotNull(idTokenClaimsRequest.get("auth_time"));
+        assertEquals(ClaimRequirement.ESSENTIAL, idTokenClaimsRequest.get("auth_time").getClaimRequirement());
+        assertNotNull(idTokenClaimsRequest.get("acr"));
+        assertEquals(Arrays.asList("urn:mace:incommon:iap:silver"), idTokenClaimsRequest.get("acr").getValuesAsListOfStrings());
     }
 
     @Test

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
@@ -286,7 +286,7 @@ class OIDCClientConfigurationTest
     @Test
     void getClaimsRequestFromWikiConfigJson() throws Exception
     {
-        // using the example string from the OIDCClaimsRequest javadoc
+        // Using the example string from the OIDCClaimsRequest javadoc
         String userInfoClaimJson = "{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":"
                 + "{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,"
                 + "\"http://example.info/claims/groups\":null}";


### PR DESCRIPTION
This PR adds the features required to specify ACR values for securing an XWiki instance with step-up authentication. 

Instead of using the `oidc.userinfoclaims` and `oidc.idtokenclaims` configuration options to build the claim sent to the IdP, the new `oidc.claims` configuration option can be used to specify the full claims JSON to send. If `oidc.claims` is not set the old configuration options are used as before, so there should be no breakage when upgrading. Note that the values of configuration options are apparently split at the `,` character, so the commas in the `oidc.claims` JSON have to be escaped as `\,`.

Example for the `oidc.claims` configuration option containing the previous default values and requesting an ACR value of `2`:

```
oidc.claims={"userinfo":{"xwiki_user_accessibility":null\,"xwiki_user_company":null\,"xwiki_user_displayHiddenDocuments":null\,"xwiki_user_editor":null\,"xwiki_user_usertype":null}\,"id_token":{"xwiki_instance_id":null\,"acr":{"values":["2"]\,"essential":true}}}
```

In the CallbackOIDCEndpoint it is checked whether the configured claims object contains ACR values. If it does, the values are compared to the ACR value returned in the id token. If no ACR value is returned or if the returned value does not match any value in the claims an exception is thrown, preventing the login attempt. This is a security measure, as the claims are sent in the URL and can be modified by the user.

See the [Keycloak step-up flow documentation](https://www.keycloak.org/docs/latest/server_admin/#_step-up-flow) and the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics) for some more details about step-up authentication.

Tested with XWiki 16.2.0 and Keycloak.

This PR only allows to secure the entire instance with one specific level of authentication. With further extensions it would be possible to secure different subwikis with different levels of authentication or even extend it to fine-grained rights management. However, that exceeds my knowledge with the XWiki codebase and is also not a requirement for us, just wanted to mention it.
