### PR TITLE
OIDC-245: OAuth access token is renewed everytime its retrieved from …

### DIFF
--- a/oauth2-client/src/main/java/org/xwiki/contrib/oidc/internal/DefaultOAuth2ClientManager.java
+++ b/oauth2-client/src/main/java/org/xwiki/contrib/oidc/internal/DefaultOAuth2ClientManager.java
@@ -136,10 +136,10 @@ public class DefaultOAuth2ClientManager implements OAuth2ClientManager
     @Override
     public Job renew(OAuth2Token token, boolean force) throws OAuth2Exception
     {
-        // For now, only renew access tokens if they expire within the next 24 hours.
+        // For now, only renew access tokens if they expire within the next 5 minutes.
         // TODO: Update the client configuration to allow users to define when a token should be renewed
         if (token instanceof NimbusOAuth2Token
-            && (force || ((NimbusOAuth2Token) token).toAccessToken().getLifetime() < 3600 * 24)) {
+            && (force || ((NimbusOAuth2Token) token).toAccessToken().getLifetime() < 60 * 5)) {
             DefaultRequest request = new DefaultRequest();
             request.setId("oauth2", token.getConfiguration().getConfigurationName(),
                 entityReferenceSerializer.serialize(token.getReference()));

--- a/oauth2-store/src/main/java/org/xwiki/contrib/oidc/internal/NimbusOAuth2Token.java
+++ b/oauth2-store/src/main/java/org/xwiki/contrib/oidc/internal/NimbusOAuth2Token.java
@@ -269,7 +269,7 @@ public class NimbusOAuth2Token implements OAuth2Token
             throw new OAuth2Exception(
                 String.format("Failed to convert access token : type [%s] is unsupported.", getType().toString()));
         } else {
-            long lifetime = Math.min(((getExpiresAt() - System.currentTimeMillis()) / 1000), 0);
+            long lifetime = Math.max(((getExpiresAt() - System.currentTimeMillis()) / 1000), 0);
             return new BearerAccessToken(getAccessToken(), lifetime, Scope.parse(getScopes()));
         }
     }


### PR DESCRIPTION
…the store

* Fixed a small bug where the lifespan of a token would always return 0.
* The access tokens are currently refreshed if they will expire in the next 24 hours. The lifespan of an access token is generally less than that, around 1 to 2 hours (according to the internet). In the case of OpenProject, it expires after 2 hours. Considering the aforementioned, I configured the tokens to refresh if they will expire in the next 5 minutes.
