### PR TITLE
OIDC-246: Allow to configure a regex based filtering of groups to be synchronized when no explicit groups mapping is present

### DIFF
--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
@@ -59,6 +59,10 @@ public class OIDCClientConfigurationClassDocumentInitializer extends AbstractMan
         xclass.addTextField(OIDCClientConfiguration.FIELD_CLAIM_GROUP, "Group claim", 255);
         xclass.addTextAreaField(OIDCClientConfiguration.FIELD_GROUP_MAPPING, "Group mapping", 50, 10,
             TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
+        xclass.addTextAreaField(OIDCClientConfiguration.FIELD_GROUP_MAPPING_INCLUDE, "Group mapping inclusions regex",
+            255, 1, TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
+        xclass.addTextAreaField(OIDCClientConfiguration.FIELD_GROUP_MAPPING_EXCLUDE, "Group mapping exclusions regex ",
+            255, 1, TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
         xclass.addTextAreaField(OIDCClientConfiguration.FIELD_ALLOWED_GROUPS, "Allowed groups", 50, 10,
             TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
         xclass.addTextAreaField(OIDCClientConfiguration.FIELD_FORBIDDEN_GROUPS, "Forbidden groups", 50, 10,

--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
@@ -385,14 +385,14 @@ public class OIDCClientConfiguration
     }
 
     /**
-     * @param groupMappingInclude the regex of groups to be excluded from synchronization if no explicit mapping is
+     * @param groupMappingExclude the regex of groups to be excluded from synchronization if no explicit mapping is
      *            present.
      *
      * @since 2.19.0
      */
-    public void setGroupMappingExclude(String groupMappingInclude)
+    public void setGroupMappingExclude(String groupMappingExclude)
     {
-        this.xobject.setLargeStringValue(FIELD_GROUP_MAPPING_EXCLUDE, groupMappingInclude);
+        this.xobject.setLargeStringValue(FIELD_GROUP_MAPPING_EXCLUDE, groupMappingExclude);
     }
 
     /**

--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
@@ -64,11 +64,15 @@ public class OIDCClientConfiguration
 
     /**
      * Name of the property containing the group mapping include regex (when group mapping is not specified).
+     *
+     * @since 2.19.0
      */
     public static final String FIELD_GROUP_MAPPING_INCLUDE = "groupsMappingInclude";
 
     /**
      * Name of the property containing the group mapping exclude regex (when group mapping is not specified).
+     *
+     * @since 2.19.0
      */
     public static final String FIELD_GROUP_MAPPING_EXCLUDE = "groupsMappingExclude";
 
@@ -362,6 +366,8 @@ public class OIDCClientConfiguration
 
     /**
      * @param groupMappingInclude the regex of groups to be synchronized if no explicit mapping is present.
+     *
+     * @since 2.19.0
      */
     public void setGroupMappingInclude(String groupMappingInclude)
     {
@@ -381,6 +387,8 @@ public class OIDCClientConfiguration
     /**
      * @param groupMappingInclude the regex of groups to be excluded from synchronization if no explicit mapping is
      *            present.
+     *
+     * @since 2.19.0
      */
     public void setGroupMappingExclude(String groupMappingInclude)
     {

--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
@@ -63,6 +63,16 @@ public class OIDCClientConfiguration
     public static final String FIELD_GROUP_MAPPING = "groupsMapping";
 
     /**
+     * Name of the property containing the group mapping include regex (when group mapping is not specified).
+     */
+    public static final String FIELD_GROUP_MAPPING_INCLUDE = "groupsMappingInclude";
+
+    /**
+     * Name of the property containing the group mapping exclude regex (when group mapping is not specified).
+     */
+    public static final String FIELD_GROUP_MAPPING_EXCLUDE = "groupsMappingExclude";
+
+    /**
      * Name of the property containing the allowed groups.
      */
     public static final String FIELD_ALLOWED_GROUPS = "allowedGroups";
@@ -338,6 +348,39 @@ public class OIDCClientConfiguration
     public void setGroupMapping(List<String> groupMapping)
     {
         this.xobject.setLargeStringValue(FIELD_GROUP_MAPPING, String.join(JOIN_CHAR, groupMapping));
+    }
+
+    /**
+     * @return the regex of groups to be synchronized if no explicit mapping is present.
+     */
+    public String getGroupMappingInclude()
+    {
+        return StringUtils.trimToNull(this.xobject.getLargeStringValue(FIELD_GROUP_MAPPING_INCLUDE));
+    }
+
+    /**
+     * @param groupMappingInclude the regex of groups to be synchronized if no explicit mapping is present.
+     */
+    public void setGroupMappingInclude(String groupMappingInclude)
+    {
+        this.xobject.setLargeStringValue(FIELD_GROUP_MAPPING_INCLUDE, groupMappingInclude);
+    }
+
+    /**
+     * @return the regex of groups to be excluded from synchronization if no explicit mapping is present.
+     */
+    public String getGroupMappingExclude()
+    {
+        return StringUtils.trimToNull(this.xobject.getLargeStringValue(FIELD_GROUP_MAPPING_EXCLUDE));
+    }
+
+    /**
+     * @param groupMappingInclude the regex of groups to be excluded from synchronization if no explicit mapping is
+     *            present.
+     */
+    public void setGroupMappingExclude(String groupMappingInclude)
+    {
+        this.xobject.setLargeStringValue(FIELD_GROUP_MAPPING_EXCLUDE, groupMappingInclude);
     }
 
     /**

--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
@@ -352,6 +352,8 @@ public class OIDCClientConfiguration
 
     /**
      * @return the regex of groups to be synchronized if no explicit mapping is present.
+     *
+     * @since 2.19.0
      */
     public String getGroupMappingInclude()
     {
@@ -368,6 +370,8 @@ public class OIDCClientConfiguration
 
     /**
      * @return the regex of groups to be excluded from synchronization if no explicit mapping is present.
+     *
+     * @since 2.19.0
      */
     public String getGroupMappingExclude()
     {

--- a/oidc-authenticator-configuration/src/test/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfigurationTest.java
+++ b/oidc-authenticator-configuration/src/test/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfigurationTest.java
@@ -83,6 +83,25 @@ class OIDCClientConfigurationTest
     }
 
     @Test
+    void getGroupsMappingRegex()
+    {
+        assertNull(this.configuration.getGroupMappingInclude());
+        assertNull(this.configuration.getGroupMappingExclude());
+
+        // check that empty string doesn't count as a set configuration
+        this.xobject.setLargeStringValue(OIDCClientConfiguration.FIELD_GROUP_MAPPING_INCLUDE, "");
+        this.xobject.setLargeStringValue(OIDCClientConfiguration.FIELD_GROUP_MAPPING_EXCLUDE, "");
+        assertNull(this.configuration.getGroupMappingInclude());
+        assertNull(this.configuration.getGroupMappingExclude());
+
+        // check that an explicit configuration counts as a config and is returned as is
+        this.xobject.setLargeStringValue(OIDCClientConfiguration.FIELD_GROUP_MAPPING_INCLUDE, "\\d+");
+        this.xobject.setLargeStringValue(OIDCClientConfiguration.FIELD_GROUP_MAPPING_EXCLUDE, "\\d+");
+        assertEquals(this.configuration.getGroupMappingInclude(), "\\d+");
+        assertEquals(this.configuration.getGroupMappingInclude(), "\\d+");
+    }
+
+    @Test
     void getUserInfoRefreshRate()
     {
         assertNull(this.configuration.getUserInfoRefreshRate());

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -1537,6 +1537,12 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             case PROP_GROUPS_MAPPING:
                 returnValue = clientConfiguration.getGroupMapping();
                 break;
+            case PROP_GROUPS_MAPPING_INCLUDE:
+                returnValue = clientConfiguration.getGroupMappingInclude();
+                break;
+            case PROP_GROUPS_MAPPING_EXCLUDE:
+                returnValue = clientConfiguration.getGroupMappingExclude();
+                break;
             case PROP_GROUPS_ALLOWED:
                 returnValue = clientConfiguration.getAllowedGroups();
                 break;

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -288,12 +288,12 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     public static final String PROP_GROUPS_MAPPING = "oidc.groups.mapping";
 
     /**
-     * @since 2.18.3
+     * @since 2.19.0
      */
     public static final String PROP_GROUPS_MAPPING_INCLUDE = "oidc.groups.mapping.include";
 
     /**
-     * @since 2.18.3
+     * @since 2.19.0
      */
     public static final String PROP_GROUPS_MAPPING_EXCLUDE = "oidc.groups.mapping.exclude";
 
@@ -1127,7 +1127,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     }
 
     /**
-     * @since 2.18.3
+     * @since 2.19.0
      */
     public String getGroupMappingIncludeRegex()
     {
@@ -1136,7 +1136,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     }
 
     /**
-     * @since 2.18.3
+     * @since 2.19.0
      */
     public String getGroupMappingExcludeRegex()
     {

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -288,6 +288,16 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     public static final String PROP_GROUPS_MAPPING = "oidc.groups.mapping";
 
     /**
+     * @since 2.18.3
+     */
+    public static final String PROP_GROUPS_MAPPING_INCLUDE = "oidc.groups.mapping.include";
+
+    /**
+     * @since 2.18.3
+     */
+    public static final String PROP_GROUPS_MAPPING_EXCLUDE = "oidc.groups.mapping.exclude";
+
+    /**
      * @since 1.10
      */
     public static final String PROP_GROUPS_ALLOWED = "oidc.groups.allowed";
@@ -1114,6 +1124,24 @@ public class OIDCClientConfiguration extends OIDCConfiguration
         }
 
         return groups;
+    }
+
+    /**
+     * @since 2.18.3
+     */
+    public String getGroupMappingIncludeRegex()
+    {
+        String regex = getProperty(PROP_GROUPS_MAPPING_INCLUDE, String.class);
+        return regex != null && !regex.isEmpty() ? regex : null;
+    }
+
+    /**
+     * @since 2.18.3
+     */
+    public String getGroupMappingExcludeRegex()
+    {
+        String regex = getProperty(PROP_GROUPS_MAPPING_EXCLUDE, String.class);
+        return regex != null && !regex.isEmpty() ? regex : null;
     }
 
     /**

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -1129,19 +1131,33 @@ public class OIDCClientConfiguration extends OIDCConfiguration
     /**
      * @since 2.19.0
      */
-    public String getGroupMappingIncludeRegex()
+    public Pattern getGroupMappingIncludePattern()
     {
-        String regex = getProperty(PROP_GROUPS_MAPPING_INCLUDE, String.class);
-        return regex != null && !regex.isEmpty() ? regex : null;
+        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_INCLUDE);
     }
 
     /**
      * @since 2.19.0
      */
-    public String getGroupMappingExcludeRegex()
+    public Pattern getGroupMappingExcludePattern()
     {
-        String regex = getProperty(PROP_GROUPS_MAPPING_EXCLUDE, String.class);
-        return regex != null && !regex.isEmpty() ? regex : null;
+        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_EXCLUDE);
+    }
+
+    private Pattern compilePropertyIntoPattern(String propertyName)
+    {
+        String regex = getProperty(propertyName, String.class);
+
+        if (StringUtils.isEmpty(regex)) {
+            return null;
+        }
+        try {
+            return Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            logger.warn("Exception while compiling regex {} configured for {}, skipping configuration", regex,
+                propertyName, e);
+            return null;
+        }
     }
 
     /**

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -676,7 +676,7 @@ public class OIDCUserManager
         for (String providerGroupName : providerGroups) {
             if (groupMapping == null) {
                 String xwikiGroup = this.configuration.toXWikiGroup(providerGroupName);
-                if (groupMatchesMappingRegex(providerGroupName, mappingIncludeRegex, mappingExcludeRegex)
+                if (groupMatchesMappingRegex(xwikiGroup, mappingIncludeRegex, mappingExcludeRegex)
                     && !xwikiUserGroupList.contains(xwikiGroup)) {
                     addUserToXWikiGroup(xwikiUserName, xwikiGroup, context);
                     userUpdated = true;
@@ -705,8 +705,7 @@ public class OIDCUserManager
                 if (!this.configuration.getInitialXWikiGroups().contains(xwikiGroupName)
                     && !providerGroups.contains(xwikiGroupName)
                     && !providerGroups.contains(xwikiGroupName.substring(XWIKI_GROUP_PREFIX.length()))
-                    && groupMatchesMappingRegex(xwikiGroupName.substring(XWIKI_GROUP_PREFIX.length()),
-                        mappingIncludeRegex, mappingExcludeRegex)) {
+                    && groupMatchesMappingRegex(xwikiGroupName, mappingIncludeRegex, mappingExcludeRegex)) {
                     removeUserFromXWikiGroup(xwikiUserName, xwikiGroupName, context);
                     userUpdated = true;
                 }
@@ -735,14 +734,20 @@ public class OIDCUserManager
      */
     private boolean groupMatchesMappingRegex(String groupName, String includeRegex, String excludeRegex)
     {
+        this.logger.debug("Checking if group name {} matches inclusion {} and exclusion {}", groupName, includeRegex,
+            excludeRegex);
         if (includeRegex != null && !groupName.matches(includeRegex)) {
+            this.logger.debug("Match faiure: group name {} doesn't match the inclusion regex {}", includeRegex);
             return false;
         }
         // either matches the inclusion or there is no inclusion, check the exclusion
         if (excludeRegex != null && groupName.matches(excludeRegex)) {
+            this.logger.debug("Match faiure: group name {} matches the exclusion regex {}", excludeRegex);
             return false;
         }
         // either matches both or there is no inclusion or exclusion mentioned
+        this.logger.debug("Match success: group name {} passes both inclusion and exclusion, or none is specified",
+            groupName);
         return true;
     }
 

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
@@ -401,6 +401,244 @@ class OIDCUserManagerTest
         assertFalse(groupContains(this.existinggroupReference, userDocument.getFullName()));
         assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
     }
+    
+    @Test
+    void updateUserInfoWithGroupSyncWithoutMappingAndIncludeRegex()
+        throws XWikiException, QueryException, OIDCException, MalformedURLException
+    {
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_INCLUDE,
+            "^[A-Za-z]*group[A-Za-z]*1$");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
+            ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
+                this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));
+
+        Issuer issuer = new Issuer("http://issuer");
+        Subject subject = new Subject("subject");
+        IDTokenClaimsSet idToken = createIDTokenClaimsSet(issuer, subject);
+        UserInfo userInfo = new UserInfo(subject);
+
+        userInfo.setClaim("groupclaim", Arrays.asList("pgroup1", "pgroup2"));
+
+        String userFullName = "XWiki.issuer-subject";
+
+        when(this.oldcore.getMockGroupService().getAllGroupsNamesForMember(userFullName, 0, 0,
+            this.oldcore.getXWikiContext())).thenReturn(Arrays.asList("XWiki.existinggroup"));
+        addMember(this.existinggroupReference, userFullName);
+        addMember(this.xwikiallgroupReference, userFullName);
+
+        assertFalse(groupContains(this.group1Reference, userFullName));
+        assertFalse(groupContains(this.group2Reference, userFullName));
+        assertTrue(groupContains(this.existinggroupReference, userFullName));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+
+        Principal principal = this.manager.updateUser(idToken, userInfo, new BearerAccessToken());
+
+        assertEquals("xwiki:XWiki.issuer-subject", principal.getName());
+
+        XWikiDocument userDocument = this.oldcore.getSpyXWiki().getDocument(
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "issuer-subject"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(userDocument.isNew());
+
+        BaseObject userObject = userDocument
+            .getXObject(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "XWikiUsers"));
+
+        assertNotNull(userObject);
+
+        OIDCUser oidcObject = new OIDCUser(userDocument.getXObject(this.oidcClassReference));
+
+        assertNotNull(oidcObject);
+        assertEquals("http://issuer", oidcObject.getIssuer());
+        assertEquals("subject", oidcObject.getSubject());
+
+        // we're expecting: user stays in initial group, gets synced in the first group, doesn't get synced in the
+        // second group and doesn't get removed from existing group, because existing group doesn't match the mapping
+        // regex
+        assertTrue(groupContains(this.pgroup1Reference, userDocument.getFullName()));
+        assertFalse(groupContains(this.pgroup2Reference, userDocument.getFullName()));
+        assertTrue(groupContains(this.existinggroupReference, userDocument.getFullName()));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+    }
+
+    @Test
+    void updateUserInfoWithGroupSyncWithoutMappingAndExcludeRegex()
+        throws XWikiException, QueryException, OIDCException, MalformedURLException
+    {
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_EXCLUDE,
+            "^[A-Za-z]*group[A-Za-z]*1$");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
+            ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
+                this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));
+
+        Issuer issuer = new Issuer("http://issuer");
+        Subject subject = new Subject("subject");
+        IDTokenClaimsSet idToken = createIDTokenClaimsSet(issuer, subject);
+        UserInfo userInfo = new UserInfo(subject);
+
+        userInfo.setClaim("groupclaim", Arrays.asList("pgroup1", "pgroup2"));
+
+        String userFullName = "XWiki.issuer-subject";
+
+        when(this.oldcore.getMockGroupService().getAllGroupsNamesForMember(userFullName, 0, 0,
+            this.oldcore.getXWikiContext())).thenReturn(Arrays.asList("XWiki.existinggroup"));
+        addMember(this.existinggroupReference, userFullName);
+        addMember(this.xwikiallgroupReference, userFullName);
+
+        assertFalse(groupContains(this.group1Reference, userFullName));
+        assertFalse(groupContains(this.group2Reference, userFullName));
+        assertTrue(groupContains(this.existinggroupReference, userFullName));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+
+        Principal principal = this.manager.updateUser(idToken, userInfo, new BearerAccessToken());
+
+        assertEquals("xwiki:XWiki.issuer-subject", principal.getName());
+
+        XWikiDocument userDocument = this.oldcore.getSpyXWiki().getDocument(
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "issuer-subject"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(userDocument.isNew());
+
+        BaseObject userObject = userDocument
+            .getXObject(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "XWikiUsers"));
+
+        assertNotNull(userObject);
+
+        OIDCUser oidcObject = new OIDCUser(userDocument.getXObject(this.oidcClassReference));
+
+        assertNotNull(oidcObject);
+        assertEquals("http://issuer", oidcObject.getIssuer());
+        assertEquals("subject", oidcObject.getSubject());
+
+        // we're expecting: user stays in initial group, gets synced out of the first group, gets synced in the
+        // second group and doesn't get removed from existing group, because existing group doesn't match the mapping
+        // exclusion, so it's included
+        assertFalse(groupContains(this.pgroup1Reference, userDocument.getFullName()));
+        assertTrue(groupContains(this.pgroup2Reference, userDocument.getFullName()));
+        assertFalse(groupContains(this.existinggroupReference, userDocument.getFullName()));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+    }
+
+    @Test
+    void updateUserInfoWithGroupSyncWithoutMappingAndIncludeExcludeRegex()
+        throws XWikiException, QueryException, OIDCException, MalformedURLException
+    {
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_INCLUDE,
+            "^.*pgroup.*$");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_EXCLUDE, ".*2$");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
+            ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
+                this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));
+
+        Issuer issuer = new Issuer("http://issuer");
+        Subject subject = new Subject("subject");
+        IDTokenClaimsSet idToken = createIDTokenClaimsSet(issuer, subject);
+        UserInfo userInfo = new UserInfo(subject);
+
+        userInfo.setClaim("groupclaim", Arrays.asList("pgroup1", "pgroup2"));
+
+        String userFullName = "XWiki.issuer-subject";
+
+        when(this.oldcore.getMockGroupService().getAllGroupsNamesForMember(userFullName, 0, 0,
+            this.oldcore.getXWikiContext())).thenReturn(Arrays.asList("XWiki.existinggroup"));
+        addMember(this.existinggroupReference, userFullName);
+        addMember(this.xwikiallgroupReference, userFullName);
+
+        assertFalse(groupContains(this.group1Reference, userFullName));
+        assertFalse(groupContains(this.group2Reference, userFullName));
+        assertTrue(groupContains(this.existinggroupReference, userFullName));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+
+        Principal principal = this.manager.updateUser(idToken, userInfo, new BearerAccessToken());
+
+        assertEquals("xwiki:XWiki.issuer-subject", principal.getName());
+
+        XWikiDocument userDocument = this.oldcore.getSpyXWiki().getDocument(
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "issuer-subject"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(userDocument.isNew());
+
+        BaseObject userObject = userDocument
+            .getXObject(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "XWikiUsers"));
+
+        assertNotNull(userObject);
+
+        OIDCUser oidcObject = new OIDCUser(userDocument.getXObject(this.oidcClassReference));
+
+        assertNotNull(oidcObject);
+        assertEquals("http://issuer", oidcObject.getIssuer());
+        assertEquals("subject", oidcObject.getSubject());
+
+        // we're expecting: user stays in initial group, gets synced in the first group, does not get synced in the
+        // second group and doesn't get removed from existing group, because existing group doesn't match the inclusion,
+        // so it's not updated included
+        assertTrue(groupContains(this.pgroup1Reference, userDocument.getFullName()));
+        assertFalse(groupContains(this.pgroup2Reference, userDocument.getFullName()));
+        assertTrue(groupContains(this.existinggroupReference, userDocument.getFullName()));
+        assertTrue(groupContains(this.xwikiallgroupReference, userFullName));
+    }
+
+    @Test
+    void updateUserInfoWithGroupSyncWithExplicitMappingIgnoresRegex()
+        throws XWikiException, QueryException, OIDCException, MalformedURLException
+    {
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING,
+            Arrays.asList("group1=pgroup1", "group1=pgroup2", "XWiki.group2=pgroup2", "existinggroup=othergroup"));
+        // it doesn't matter that these are including and excluding the same group, we're testing that they are ignored
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_INCLUDE, "\\d+");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_EXCLUDE, "\\d+");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
+            ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
+                this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));
+
+        Issuer issuer = new Issuer("http://issuer");
+        Subject subject = new Subject("subject");
+        IDTokenClaimsSet idToken = createIDTokenClaimsSet(issuer, subject);
+        UserInfo userInfo = new UserInfo(subject);
+
+        userInfo.setClaim("groupclaim", Arrays.asList("pgroup1", "pgroup2"));
+
+        String userFullName = "XWiki.issuer-subject";
+
+        when(this.oldcore.getMockGroupService().getAllGroupsNamesForMember(userFullName, 0, 0,
+            this.oldcore.getXWikiContext())).thenReturn(Arrays.asList("XWiki.existinggroup"));
+        addMember(this.existinggroupReference, "XWiki.issuer-subject");
+
+        assertFalse(groupContains(this.group1Reference, userFullName));
+        assertFalse(groupContains(this.group2Reference, userFullName));
+        assertTrue(groupContains(this.existinggroupReference, userFullName));
+
+        Principal principal = this.manager.updateUser(idToken, userInfo, new BearerAccessToken());
+
+        assertEquals("xwiki:XWiki.issuer-subject", principal.getName());
+
+        XWikiDocument userDocument = this.oldcore.getSpyXWiki().getDocument(
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "issuer-subject"),
+            this.oldcore.getXWikiContext());
+
+        assertFalse(userDocument.isNew());
+
+        BaseObject userObject = userDocument
+            .getXObject(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "XWikiUsers"));
+
+        assertNotNull(userObject);
+
+        OIDCUser oidcObject = new OIDCUser(userDocument.getXObject(this.oidcClassReference));
+
+        assertNotNull(oidcObject);
+        assertEquals("http://issuer", oidcObject.getIssuer());
+        assertEquals("subject", oidcObject.getSubject());
+
+        assertTrue(groupContains(this.group1Reference, userDocument.getFullName()));
+        assertTrue(groupContains(this.group2Reference, userDocument.getFullName()));
+        assertFalse(groupContains(this.existinggroupReference, userDocument.getFullName()));
+    }
 
     @Test
     void updateUserInfoWithGroupSyncWithMapping()

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
@@ -408,7 +408,7 @@ class OIDCUserManagerTest
     {
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_INCLUDE,
-            "^[A-Za-z]*group[A-Za-z]*1$");
+            "^XWiki\\.[A-Za-z]*group[A-Za-z]*1$");
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
             ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
                 this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));
@@ -468,7 +468,7 @@ class OIDCUserManagerTest
     {
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM, "groupclaim");
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_GROUPS_MAPPING_EXCLUDE,
-            "^[A-Za-z]*group[A-Za-z]*1$");
+            "^XWiki\\.[A-Za-z]*group[A-Za-z]*1$");
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USERINFOCLAIMS,
             ListUtils.sum(OIDCClientConfiguration.DEFAULT_USERINFOCLAIMS, Arrays.asList(
                 this.oldcore.getConfigurationSource().<String>getProperty(OIDCClientConfiguration.PROP_GROUPS_CLAIM))));


### PR DESCRIPTION
Added configuration of groups to be synched based on 2 regex: one for specifying only groups to include and one for specifying the groups to exclude. Either of the strategies can be used or both strategies can be used.