### PR TITLE
OIDC-280: OIDC secret field is sent as a hashed value

### DIFF
--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
@@ -28,6 +28,7 @@ import org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration;
 import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.TextAreaClass;
+import com.xpn.xwiki.objects.meta.PasswordMetaClass;
 
 /**
  * Document initializer for the OIDC client configuration class.
@@ -77,7 +78,7 @@ public class OIDCClientConfigurationClassDocumentInitializer extends AbstractMan
         xclass.addTextField(OIDCClientConfiguration.FIELD_ENDPOINT_USERINFO, "User info OIDC endpoint", 255);
         xclass.addTextField(OIDCClientConfiguration.FIELD_ENDPOINT_LOGOUT, "Logout OIDC endpoint", 255);
         xclass.addTextField(OIDCClientConfiguration.FIELD_CLIENT_ID, "Client ID", 255);
-        xclass.addPasswordField(OIDCClientConfiguration.FIELD_CLIENT_SECRET, "Secret", 255);
+        xclass.addPasswordField(OIDCClientConfiguration.FIELD_CLIENT_SECRET, "Secret", 255, PasswordMetaClass.CLEAR);
         xclass.addStaticListField(OIDCClientConfiguration.FIELD_ENDPOINT_TOKEN_METHOD, "Token endpoint authentication method",
             String.join(PIPE, "client_secret_basic", "client_secret_post"),
             OIDCClientConfiguration.DEFAULT_TOKEN_ENDPOINT_METHOD);


### PR DESCRIPTION
Marked secret field as CLEAR storage type to be able to access the value of the secret.