### PR TITLE
OIDC-297: Allow configuring the forbidden pattern and replacement when formatting the username and user subject

### DIFF
--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/internal/store/OIDCClientConfigurationClassDocumentInitializer.java
@@ -69,7 +69,11 @@ public class OIDCClientConfigurationClassDocumentInitializer extends AbstractMan
         xclass.addTextAreaField(OIDCClientConfiguration.FIELD_FORBIDDEN_GROUPS, "Forbidden groups", 50, 10,
             TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
         xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_SUBJECT, "Subject formatter", 255);
+        xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_PATTERN, "Subject forbidden pattern", 255);
+        xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_REPLACEMENT, "Subject forbidden replacement", 255);
         xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_NAME, "XWiki username formatter", 255);
+        xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_NAME_FORBIDDEN_PATTERN, "XWiki username forbidden pattern", 255);
+        xclass.addTextField(OIDCClientConfiguration.FIELD_FORMATTER_USER_NAME_FORBIDDEN_REPLACEMENT, "XWiki username forbidden replacement", 255);
         xclass.addTextAreaField(OIDCClientConfiguration.FIELD_USER_MAPPING, "User mapping", 50, 10,
             TextAreaClass.EditorType.PURE_TEXT, TextAreaClass.ContentType.PURE_TEXT);
         xclass.addTextField(OIDCClientConfiguration.FIELD_XWIKI_PROVIDER, "XWiki provider", 255);

--- a/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
+++ b/oidc-authenticator-configuration/src/main/java/org/xwiki/contrib/oidc/auth/store/OIDCClientConfiguration.java
@@ -110,8 +110,32 @@ public class OIDCClientConfiguration
 
     /**
      * Name of the property containing the user subject formatter.
+     * @since 2.23.0
+     */
+    public static final String FIELD_FORMATTER_USER_NAME_FORBIDDEN_PATTERN = "userNameForbiddenPattern";
+
+    /**
+     * Name of the property containing the user subject formatter.
+     * @since 2.23.0
+     */
+    public static final String FIELD_FORMATTER_USER_NAME_FORBIDDEN_REPLACEMENT = "userNameForbiddenReplacement";
+
+    /**
+     * Name of the property containing the user subject formatter.
      */
     public static final String FIELD_FORMATTER_USER_SUBJECT = "userSubjectFormatter";
+
+    /**
+     * Name of the property containing the user subject formatter.
+     * @since 2.23.0
+     */
+    public static final String FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_PATTERN = "userSubjectForbiddenPattern";
+
+    /**
+     * Name of the property containing the user subject formatter.
+     * @since 2.23.0
+     */
+    public static final String FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_REPLACEMENT = "userSubjectForbiddenReplacement";
 
     /**
      * Name of the property containing the user mapping.
@@ -444,7 +468,45 @@ public class OIDCClientConfiguration
     }
 
     /**
-     * @return the user name formatter
+     * @return the user subject forbidden pattern
+     * @since 2.23.0
+     */
+    public String getUserSubjectForbiddenPattern()
+    {
+        return this.xobject.getStringValue(FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_PATTERN);
+    }
+
+    /**
+     * @param userSubjectFormatterForbiddenPattern the forbidden pattern to set
+     * @since 2.23.0
+     */
+    public void setUserSubjectForbiddenPattern(String userSubjectFormatterForbiddenPattern)
+    {
+        this.xobject.setStringValue(FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_PATTERN,
+                userSubjectFormatterForbiddenPattern);
+    }
+
+    /**
+     * @return the user subject forbidden pattern
+     * @since 2.23.0
+     */
+    public String getUserSubjectForbiddenReplacement()
+    {
+        return this.xobject.getStringValue(FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_REPLACEMENT);
+    }
+
+    /**
+     * @param  userSubjectFormatterForbiddenReplacement the user subject forbidden pattern
+     * @since 2.23.0
+     */
+    public void setUserSubjectForbiddenReplacement(String userSubjectFormatterForbiddenReplacement)
+    {
+        this.xobject.setStringValue(FIELD_FORMATTER_USER_SUBJECT_FORBIDDEN_REPLACEMENT,
+                userSubjectFormatterForbiddenReplacement);
+    }
+
+    /**
+     * @return the username formatter
      */
     public String getUserNameFormatter()
     {
@@ -452,11 +514,50 @@ public class OIDCClientConfiguration
     }
 
     /**
-     * @param userNameFormatter the user name formatter
+     * @param userNameFormatter the username formatter
      */
     public void setUserNameFormatter(String userNameFormatter)
     {
         this.xobject.setStringValue(FIELD_FORMATTER_USER_NAME, userNameFormatter);
+    }
+
+
+    /**
+     * @return the username forbidden pattern
+     * @since 2.23.0
+     */
+    public String getUserNameForbiddenPattern()
+    {
+        return this.xobject.getStringValue(FIELD_FORMATTER_USER_NAME_FORBIDDEN_PATTERN);
+    }
+
+    /**
+     * @param userNameFormatterForbiddenPattern the username forbidden pattern to set
+     * @since 2.23.0
+     */
+    public void setUserNameForbiddenPattern(String userNameFormatterForbiddenPattern)
+    {
+        this.xobject.setStringValue(FIELD_FORMATTER_USER_NAME_FORBIDDEN_PATTERN,
+                userNameFormatterForbiddenPattern);
+    }
+
+    /**
+     * @return the username forbidden pattern
+     * @since 2.23.0
+     */
+    public String getUserNameForbiddenReplacement()
+    {
+        return this.xobject.getStringValue(FIELD_FORMATTER_USER_NAME_FORBIDDEN_REPLACEMENT);
+    }
+
+    /**
+     * @param  userNameFormatterForbiddenReplacement the username forbidden pattern
+     * @since 2.23.0
+     */
+    public void setUserNameForbiddenReplacement(String userNameFormatterForbiddenReplacement)
+    {
+        this.xobject.setStringValue(FIELD_FORMATTER_USER_NAME_FORBIDDEN_REPLACEMENT,
+                userNameFormatterForbiddenReplacement);
     }
 
     /**

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfiguration.java
@@ -78,6 +78,7 @@ import org.xwiki.contrib.oidc.provider.internal.endpoint.LogoutOIDCEndpoint;
 import org.xwiki.contrib.oidc.provider.internal.endpoint.RegisterAddOIDCEndpoint;
 import org.xwiki.contrib.oidc.provider.internal.endpoint.TokenOIDCEndpoint;
 import org.xwiki.contrib.oidc.provider.internal.endpoint.UserInfoOIDCEndpoint;
+import org.xwiki.contrib.usercommon.formatter.UserFormatterFactory;
 import org.xwiki.instance.InstanceIdManager;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.LocalDocumentReference;
@@ -170,6 +171,16 @@ public class OIDCClientConfiguration extends OIDCConfiguration
 
     public static final String PROP_USER_NAMEFORMATER = "oidc.user.nameFormater";
 
+    /**
+     * @since 2.23.0
+     */
+    public static final String PROP_USER_NAMEFORBIDDENPATTERN = "oidc.user.nameForbiddenPattern";
+
+    /**
+     * @since 2.23.0
+     */
+    public static final String PROP_USER_NAMEFORBIDDENREPLACEMENT = "oidc.user.nameForbiddenReplacement";
+
     public static final String DEFAULT_USER_NAMEFORMATER =
         "${oidc.issuer.host._clean}-${oidc.user.preferredUsername._clean}";
 
@@ -177,6 +188,16 @@ public class OIDCClientConfiguration extends OIDCConfiguration
      * @since 1.11
      */
     public static final String PROP_USER_SUBJECTFORMATER = "oidc.user.subjectFormater";
+
+    /**
+     * @since 2.23.0
+     */
+    public static final String PROP_USER_SUBJECTFORBIDDENREPLACEMENT = "oidc.user.subjectForbiddenReplacement";
+
+    /**
+     * @since 2.23.0
+     */
+    public static final String PROP_USER_SUBJECTFORBIDDENPATTERN = "oidc.user.subjectForbiddenPattern";
 
     /**
      * @since 1.18
@@ -687,6 +708,38 @@ public class OIDCClientConfiguration extends OIDCConfiguration
         return userFormatter;
     }
 
+    private Pattern getForbiddenPattern(String prop)
+    {
+        return compilePropertyIntoPattern(prop, UserFormatterFactory.DEFAULT_FORBIDDEN_PATTERN);
+    }
+
+    private String getForbiddenReplacement(String prop)
+    {
+        String forbiddenReplacement = getProperty(prop, String.class);
+        if (StringUtils.isEmpty(forbiddenReplacement)) {
+            // The condition is only correct because DEFAULT_FORBIDDEN_REPLACEMENT is the empty String
+            return UserFormatterFactory.DEFAULT_FORBIDDEN_REPLACEMENT;
+        }
+
+        return forbiddenReplacement;
+    }
+
+    /**
+     * @since 2.23.0
+     */
+    public Pattern getSubjectForbiddenPattern()
+    {
+        return getForbiddenPattern(PROP_USER_SUBJECTFORBIDDENPATTERN);
+    }
+
+    /**
+     * @since 2.23.0
+     */
+    public String getSubjectForbiddenReplacement()
+    {
+        return getForbiddenReplacement(PROP_USER_SUBJECTFORBIDDENREPLACEMENT);
+    }
+
     /**
      * @since 1.11
      */
@@ -698,6 +751,22 @@ public class OIDCClientConfiguration extends OIDCConfiguration
         }
 
         return userFormatter;
+    }
+
+    /**
+     * @since 2.23.0
+     */
+    public Pattern getXWikiUserNameForbiddenPattern()
+    {
+        return getForbiddenPattern(PROP_USER_NAMEFORBIDDENPATTERN);
+    }
+
+    /**
+     * @since 2.23.0
+     */
+    public String getXWikiUserNameForbiddenReplacement()
+    {
+        return getForbiddenReplacement(PROP_USER_NAMEFORBIDDENREPLACEMENT);
     }
 
     /**
@@ -1217,7 +1286,7 @@ public class OIDCClientConfiguration extends OIDCConfiguration
      */
     public Pattern getGroupMappingIncludePattern()
     {
-        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_INCLUDE);
+        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_INCLUDE, null);
     }
 
     /**
@@ -1225,22 +1294,23 @@ public class OIDCClientConfiguration extends OIDCConfiguration
      */
     public Pattern getGroupMappingExcludePattern()
     {
-        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_EXCLUDE);
+        return compilePropertyIntoPattern(PROP_GROUPS_MAPPING_EXCLUDE, null);
     }
 
-    private Pattern compilePropertyIntoPattern(String propertyName)
+    private Pattern compilePropertyIntoPattern(String propertyName, Pattern def)
     {
         String regex = getProperty(propertyName, String.class);
 
         if (StringUtils.isEmpty(regex)) {
-            return null;
+            return def;
         }
         try {
+            // TODO: don't compile each time (but allow changes coming from the wiki configuration)
             return Pattern.compile(regex);
         } catch (PatternSyntaxException e) {
             logger.warn("Exception while compiling regex {} configured for {}, skipping configuration", regex,
                 propertyName, e);
-            return null;
+            return def;
         }
     }
 
@@ -1696,8 +1766,20 @@ public class OIDCClientConfiguration extends OIDCConfiguration
             case PROP_USER_SUBJECTFORMATER:
                 returnValue = clientConfiguration.getUserSubjectFormatter();
                 break;
+            case PROP_USER_SUBJECTFORBIDDENPATTERN:
+                returnValue = clientConfiguration.getUserSubjectForbiddenPattern();
+                break;
+            case PROP_USER_SUBJECTFORBIDDENREPLACEMENT:
+                returnValue = clientConfiguration.getUserSubjectForbiddenReplacement();
+                break;
             case PROP_USER_NAMEFORMATER:
                 returnValue = clientConfiguration.getUserNameFormatter();
+                break;
+            case PROP_USER_NAMEFORBIDDENPATTERN:
+                returnValue = clientConfiguration.getUserNameForbiddenPattern();
+                break;
+            case PROP_USER_NAMEFORBIDDENREPLACEMENT:
+                returnValue = clientConfiguration.getUserNameForbiddenReplacement();
                 break;
             case PROP_USER_MAPPING:
                 returnValue = clientConfiguration.getUserMapping();

--- a/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
+++ b/oidc-authenticator/src/main/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManager.java
@@ -424,7 +424,10 @@ public class OIDCUserManager
         // Check allowed/forbidden groups
         checkAllowedGroups(providerGroups);
 
-        UserFormatter userFormatter = userFormatterFactory.create(createFormatMap(idToken, userInfo));
+        Map<String, String> variables = createFormatMap(idToken, userInfo);
+        Pattern forbiddenPattern = this.configuration.getSubjectForbiddenPattern();
+        String forbiddenReplacement = this.configuration.getSubjectForbiddenReplacement();
+        UserFormatter userFormatter = userFormatterFactory.create(variables, forbiddenPattern, forbiddenReplacement);
 
         String formattedSubject = userFormatter.format(this.configuration.getSubjectFormater());
 
@@ -909,6 +912,8 @@ public class OIDCUserManager
         SpaceReference spaceReference = new SpaceReference(xcontext.getMainXWiki(), "XWiki");
 
         // Generate default document name
+        userFormatter.setForbiddenPattern(this.configuration.getXWikiUserNameForbiddenPattern());
+        userFormatter.setForbiddenReplacement(this.configuration.getXWikiUserNameForbiddenReplacement());
         String documentName = userFormatter.format(this.configuration.getXWikiUserNameFormater());
 
         if (StringUtils.isEmpty(documentName)) {

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
@@ -45,6 +45,7 @@ import org.xwiki.contrib.oidc.OAuth2TokenStore;
 import org.xwiki.contrib.oidc.auth.store.OIDCClientConfigurationStore;
 import org.xwiki.contrib.oidc.provider.internal.OIDCManager;
 import org.xwiki.contrib.oidc.provider.internal.endpoint.TokenOIDCEndpoint;
+import org.xwiki.contrib.usercommon.formatter.UserFormatterFactory;
 import org.xwiki.properties.ConverterManager;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -244,6 +245,34 @@ class OIDCClientConfigurationTest
     }
 
     @Test
+    void getSubjectForbiddenPatternAndReplacementFromWikiConfig() throws Exception
+    {
+        org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration = setUpWikiConfig();
+
+        String subjectForbiddenPattern = "\\.";
+        when(wikiConfiguration.getUserSubjectForbiddenPattern()).thenReturn(subjectForbiddenPattern);
+        assertEquals(subjectForbiddenPattern, this.configuration.getSubjectForbiddenPattern().pattern());
+
+        subjectForbiddenPattern = "";
+        when(wikiConfiguration.getUserSubjectForbiddenPattern()).thenReturn(subjectForbiddenPattern);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_PATTERN, this.configuration.getSubjectForbiddenPattern());
+
+        subjectForbiddenPattern = null;
+        when(wikiConfiguration.getUserSubjectForbiddenPattern()).thenReturn(subjectForbiddenPattern);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_PATTERN, this.configuration.getSubjectForbiddenPattern());
+
+        String subjectForbiddenReplacement = "_";
+        when(wikiConfiguration.getUserSubjectForbiddenReplacement()).thenReturn(subjectForbiddenReplacement);
+        assertEquals(subjectForbiddenReplacement, this.configuration.getSubjectForbiddenReplacement());
+
+        when(wikiConfiguration.getUserSubjectForbiddenReplacement()).thenReturn("");
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_REPLACEMENT, this.configuration.getSubjectForbiddenReplacement());
+
+        when(wikiConfiguration.getUserSubjectForbiddenReplacement()).thenReturn(null);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_REPLACEMENT, this.configuration.getSubjectForbiddenReplacement());
+    }
+
+    @Test
     void getXWikiUserNameFormatterFromWikiConfig() throws Exception
     {
         org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration = setUpWikiConfig();
@@ -252,6 +281,34 @@ class OIDCClientConfigurationTest
         when(wikiConfiguration.getUserNameFormatter()).thenReturn(userNameFormatter);
 
         assertEquals(userNameFormatter, this.configuration.getXWikiUserNameFormater());
+    }
+
+    @Test
+    void getXWikiUserNameForbiddenPatternAndReplacementFromWikiConfig() throws Exception
+    {
+        org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration = setUpWikiConfig();
+
+        String xwikiUsernameForbiddenPattern = "\\.";
+        when(wikiConfiguration.getUserNameForbiddenPattern()).thenReturn(xwikiUsernameForbiddenPattern);
+        assertEquals(xwikiUsernameForbiddenPattern, this.configuration.getXWikiUserNameForbiddenPattern().pattern());
+
+        xwikiUsernameForbiddenPattern = "";
+        when(wikiConfiguration.getUserNameForbiddenPattern()).thenReturn(xwikiUsernameForbiddenPattern);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_PATTERN, this.configuration.getXWikiUserNameForbiddenPattern());
+
+        xwikiUsernameForbiddenPattern = null;
+        when(wikiConfiguration.getUserNameForbiddenPattern()).thenReturn(xwikiUsernameForbiddenPattern);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_PATTERN, this.configuration.getXWikiUserNameForbiddenPattern());
+
+        String xwikiUsernameForbiddenReplacement = "_";
+        when(wikiConfiguration.getUserNameForbiddenReplacement()).thenReturn(xwikiUsernameForbiddenReplacement);
+        assertEquals(xwikiUsernameForbiddenReplacement, this.configuration.getXWikiUserNameForbiddenReplacement());
+
+        when(wikiConfiguration.getUserNameForbiddenReplacement()).thenReturn("");
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_REPLACEMENT, this.configuration.getXWikiUserNameForbiddenReplacement());
+
+        when(wikiConfiguration.getUserNameForbiddenReplacement()).thenReturn(null);
+        assertEquals(UserFormatterFactory.DEFAULT_FORBIDDEN_REPLACEMENT, this.configuration.getXWikiUserNameForbiddenReplacement());
     }
 
     @Test

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCClientConfigurationTest.java
@@ -35,8 +35,6 @@ import java.util.stream.Collectors;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.container.Container;
 import org.xwiki.container.Request;
@@ -66,6 +64,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -113,7 +115,13 @@ class OIDCClientConfigurationTest
         org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration =
             mock(org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration.class);
         when(this.oidcClientConfigurationStore.getOIDCClientConfiguration(configName)).thenReturn(wikiConfiguration);
-
+        when(this.converterManager.convert(same(String.class), anyString())).thenAnswer(i -> i.getArgument(1));
+        when(this.converterManager.convert(
+                argThat(type -> type instanceof Class && List.class.isAssignableFrom((Class<?>) type)),
+                anyList())
+        ).thenAnswer(i -> i.getArgument(1));
+        when(this.converterManager.convert(same(Boolean.class), anyString())).thenAnswer(i -> Boolean.parseBoolean(i.getArgument(1)));
+        when(this.converterManager.convert(same(Integer.class), anyInt())).thenAnswer(i -> i.getArgument(1));
         return wikiConfiguration;
     }
 
@@ -130,7 +138,6 @@ class OIDCClientConfigurationTest
         providerMapping.put("d", Collections.singleton("XWiki.c"));
         List<String> mappingAsString = Arrays.asList("a=b", "XWiki.c=d");
         when(wikiConfiguration.getGroupMapping()).thenReturn(mappingAsString);
-        when(this.converterManager.convert(eq(List.class), eq(mappingAsString))).thenReturn(mappingAsString);
 
         OIDCClientConfiguration.GroupMapping groupMapping = this.configuration.getGroupMapping();
         assertEquals(xwikiMapping, groupMapping.getXWikiMapping());
@@ -172,7 +179,6 @@ class OIDCClientConfigurationTest
 
         URI uri = new URI("/endpoint");
         when(wikiConfiguration.getUserInfoEndpoint()).thenReturn(uri.toString());
-        when(this.converterManager.convert(String.class, uri.toString())).thenReturn(uri.toString());
         when(this.converterManager.convert(URI.class, uri.toString())).thenReturn(uri);
 
         Endpoint endpoint = this.configuration.getUserInfoOIDCEndpoint();
@@ -182,7 +188,6 @@ class OIDCClientConfigurationTest
 
         List<String> list = Arrays.asList("key1:value11", "key1:value12", "key2:value2", "alone", ":", "");
         when(wikiConfiguration.getUserInfoEndpointHeaders()).thenReturn(list);
-        when(this.converterManager.convert(eq(List.class), eq(list))).thenReturn(list);
 
         Map<String, List<String>> headers = new LinkedHashMap<>();
         headers.put("key1", Arrays.asList("value11", "value12"));
@@ -234,7 +239,6 @@ class OIDCClientConfigurationTest
 
         String subjectFormatter = "loremipsum";
         when(wikiConfiguration.getUserSubjectFormatter()).thenReturn(subjectFormatter);
-        when(this.converterManager.convert(String.class, subjectFormatter)).thenReturn(subjectFormatter);
 
         assertEquals(subjectFormatter, this.configuration.getSubjectFormater());
     }
@@ -246,7 +250,6 @@ class OIDCClientConfigurationTest
 
         String userNameFormatter = "loremipsum";
         when(wikiConfiguration.getUserNameFormatter()).thenReturn(userNameFormatter);
-        when(this.converterManager.convert(String.class, userNameFormatter)).thenReturn(userNameFormatter);
 
         assertEquals(userNameFormatter, this.configuration.getXWikiUserNameFormater());
     }
@@ -261,7 +264,6 @@ class OIDCClientConfigurationTest
         mapping.put("c", "d");
         List<String> mappingAsString = Arrays.asList("a=b", "c=d");
         when(wikiConfiguration.getUserMapping()).thenReturn(mappingAsString);
-        when(this.converterManager.convert(eq(List.class), eq(mappingAsString))).thenReturn(mappingAsString);
 
         assertEquals(mapping, this.configuration.getUserMapping());
     }
@@ -273,7 +275,6 @@ class OIDCClientConfigurationTest
 
         Integer refreshRate = 4269;
         when(wikiConfiguration.getUserInfoRefreshRate()).thenReturn(refreshRate);
-        when(this.converterManager.convert(Integer.class, refreshRate)).thenReturn(refreshRate);
 
         assertEquals(refreshRate, this.configuration.getUserInfoRefreshRate());
     }
@@ -285,11 +286,9 @@ class OIDCClientConfigurationTest
 
         List<String> idTokenClaims = Arrays.asList("test1", "test2");
         when(wikiConfiguration.getIdTokenClaims()).thenReturn(idTokenClaims);
-        when(this.converterManager.convert(any(), eq(idTokenClaims))).thenReturn(idTokenClaims);
 
         List<String> userInfoClaims = Arrays.asList("test3", "test4");
         when(wikiConfiguration.getUserInfoClaims()).thenReturn(userInfoClaims);
-        when(this.converterManager.convert(any(), eq(userInfoClaims))).thenReturn(userInfoClaims);
 
         OIDCClaimsRequest claimsRequest = this.configuration.getClaimsRequest();
 
@@ -305,14 +304,7 @@ class OIDCClientConfigurationTest
     @Test
     void getResponseTypeFromWikiConfig() throws Exception
     {
-        when(this.converterManager.convert(same(List.class), any())).thenAnswer(new Answer<List>()
-        {
-            @Override
-            public List answer(InvocationOnMock invocation) throws Throwable
-            {
-                return invocation.getArgument(1);
-            }
-        });
+        org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration = setUpWikiConfig();
 
         // No response type is set
         assertEquals(ResponseType.CODE, this.configuration.getResponseType());
@@ -322,8 +314,6 @@ class OIDCClientConfigurationTest
 
         // The response type is set in xwiki.properties
         assertEquals(ResponseType.TOKEN, this.configuration.getResponseType());
-
-        org.xwiki.contrib.oidc.auth.store.OIDCClientConfiguration wikiConfiguration = setUpWikiConfig();
 
         // The wiki configuration is initialized but the response type is still set only in xwiki.properties
         when(wikiConfiguration.getResponseType()).thenReturn(List.of());

--- a/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
+++ b/oidc-authenticator/src/test/java/org/xwiki/contrib/oidc/auth/internal/OIDCUserManagerTest.java
@@ -727,8 +727,12 @@ class OIDCUserManagerTest
     {
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_NAMEFORMATER,
             "custom-${oidc.user.mail}-${oidc.user.mail.upperCase}-${oidc.user.mail.clean.upperCase}");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_NAMEFORBIDDENPATTERN, "@");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_NAMEFORBIDDENREPLACEMENT, "_AT_");
         this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_SUBJECTFORMATER,
             "custom-${oidc.user.mail}-${oidc.user.mail.upperCase}-${oidc.user.mail.clean.upperCase}");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_SUBJECTFORBIDDENPATTERN, "com");
+        this.oldcore.getConfigurationSource().setProperty(OIDCClientConfiguration.PROP_USER_SUBJECTFORBIDDENREPLACEMENT, "MOC");
 
         Subject subject = new Subject("subject");
         UserInfo userInfo = new UserInfo(subject);
@@ -747,11 +751,11 @@ class OIDCUserManagerTest
 
         Principal principal = this.manager.updateUser(userInfo);
 
-        assertEquals("xwiki:XWiki.custom-mail@domain\\.com-MAIL@DOMAIN\\.COM-MAILDOMAINCOM", principal.getName());
+        assertEquals("xwiki:XWiki.custom-mail@domain\\.com-MAIL@DOMAIN\\.COM-MAIL_AT_DOMAIN\\.COM", principal.getName());
 
         XWikiDocument userDocument =
             this.oldcore.getSpyXWiki().getDocument(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(),
-                "XWiki", "custom-mail@domain.com-MAIL@DOMAIN.COM-MAILDOMAINCOM"), this.oldcore.getXWikiContext());
+                "XWiki", "custom-mail@domain.com-MAIL@DOMAIN.COM-MAIL_AT_DOMAIN.COM"), this.oldcore.getXWikiContext());
 
         assertFalse(userDocument.isNew());
 
@@ -769,7 +773,7 @@ class OIDCUserManagerTest
 
         assertNotNull(oidcObject);
         assertEquals("http://issuer", oidcObject.getIssuer());
-        assertEquals("custom-mail@domain.com-MAIL@DOMAIN.COM-MAILDOMAINCOM", oidcObject.getSubject());
+        assertEquals("custom-mail@domain.com-MAIL@DOMAIN.COM-MAIL@DOMAIN.MOC", oidcObject.getSubject());
     }
 
     @Test


### PR DESCRIPTION
https://jira.xwiki.org/browse/OIDC-297

We wire configuration properties to the forbidden pattern and replacement features of the usercommon formatter module.