### PR TITLE
Also expose OAuth AS metadata at .well-known/oauth-authorization-server

### DIFF
--- a/oidc-provider/src/main/java/org/xwiki/contrib/oidc/provider/internal/endpoint/ConfigurationOIDCEndpoint.java
+++ b/oidc-provider/src/main/java/org/xwiki/contrib/oidc/provider/internal/endpoint/ConfigurationOIDCEndpoint.java
@@ -47,10 +47,16 @@ import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 
 /**
  * Return provider configuration (mostly various endpoints URLs).
+ * <p>
+ * Exposed both as OpenID Connect Discovery
+ * ({@code .well-known/openid-configuration}) and as OAuth 2.0 Authorization Server Metadata
+ * ({@code .well-known/oauth-authorization-server}) so MCP and other OAuth clients that prefer
+ * RFC 8414 can discover the same endpoints.
+ * </p>
  * 
  * @version $Id$
  */
-@Component(hints = {"", ".well-known/openid-configuration"})
+@Component(hints = {"", ".well-known/openid-configuration", ".well-known/oauth-authorization-server"})
 @Singleton
 public class ConfigurationOIDCEndpoint implements OIDCEndpoint
 {


### PR DESCRIPTION
## Summary
- Register the existing OIDC discovery handler for `.well-known/oauth-authorization-server` in addition to `.well-known/openid-configuration`.
- Lets MCP/OAuth clients that follow RFC 8414 discover XWiki's authorization/token/registration endpoints instead of falling back to guessing `/authorize` on the host root.

## Context
XWiki already returns correct OpenID Connect Discovery JSON at `/oidc/.well-known/openid-configuration`. MCP clients (and similar OAuth resource clients) often request `/oidc/.well-known/oauth-authorization-server` first per RFC 8414. That path currently 404s, which breaks discovery even when Protected Resource Metadata correctly points at the `/oidc` issuer.

## Test plan
- [ ] `GET /oidc/.well-known/oauth-authorization-server` returns 200 with the same metadata JSON as openid-configuration
- [ ] `GET /oidc/.well-known/openid-configuration` still returns 200 unchanged
- [ ] Confirm `authorization_endpoint`, `token_endpoint`, `issuer`, and `registration_endpoint` are present